### PR TITLE
remove obsolete information

### DIFF
--- a/README
+++ b/README
@@ -134,11 +134,6 @@ SUPPORT AND MAILING LIST
 NOTE: the information below is still avtive, but please consider to
 contact discussion forum on CPAN and/or github repositry first. 
 
-There is a mailing list for general discussion and announcements.  See
-the Savannah mailing list page for details:
-
-https://savannah.nongnu.org/mail/?group=netftpserver
-
 Bug reports, feature requests, and so on should be sent to the mailing
 list.
 


### PR DESCRIPTION
Hi,
I am taking part to the CPAN Challenge and I have been assigned Net::FTPServer. I have just started. I noted that the URL for the mailing list is obsolete and there is no mailing list at the address. I hope I am not breaking any rule or etiquette..
Ben
