### PR TITLE
Double default memory limit. Tame abort test.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,19 @@
+requires 'BSD::Resource';
+requires 'Carp';
+requires 'DynaLoader';
+requires 'Fcntl';
+requires 'Getopt::Long';
+requires 'IO::Dir';
+requires 'IO::File';
+requires 'IO::Handle';
+requires 'IO::Scalar';
+requires 'IO::Seekable';
+requires 'IO::Select';
+requires 'IO::Socket';
+requires 'IPC::Open2';
+requires 'POSIX';
+requires 'Socket';
+requires 'Sys::Hostname';
+requires 'Sys::Syslog';
+
+test_requires 'Test::More';

--- a/lib/Net/FTPServer.pm
+++ b/lib/Net/FTPServer.pm
@@ -358,7 +358,7 @@ process and are important in avoiding denial of service (DoS)
 attacks against the FTP server.
 
  Resource         Default   Unit
- limit memory       16384   KBytes  Amount of memory per child
+ limit memory       32768   KBytes  Amount of memory per child
  limit nr processes    10   (none)  Number of processes
  limit nr files        20   (none)  Number of open files
 
@@ -367,7 +367,7 @@ limit to C<-1>.
 
 Example:
 
- limit memory:       32768
+ limit memory:       65536
  limit nr processes:    20
  limit nr files:        40
 
@@ -2680,7 +2680,7 @@ sub run
     # Perform normal per-process limits.
     if ($r == 0)
       {
-	my $limit = 1024 * ($self->config ("limit memory") || 16384);
+	my $limit = 1024 * ($self->config ("limit memory") || 32768);
 	$self->_set_rlimit ("RLIMIT_DATA", $limit) if $limit >= 0;
 
 	$limit = $self->config ("limit nr processes") || 10;

--- a/lib/Net/FTPServer.pm
+++ b/lib/Net/FTPServer.pm
@@ -358,7 +358,7 @@ process and are important in avoiding denial of service (DoS)
 attacks against the FTP server.
 
  Resource         Default   Unit
- limit memory       32768   KBytes  Amount of memory per child
+ limit memory       65536   KBytes  Amount of memory per child
  limit nr processes    10   (none)  Number of processes
  limit nr files        20   (none)  Number of open files
 
@@ -2680,7 +2680,7 @@ sub run
     # Perform normal per-process limits.
     if ($r == 0)
       {
-	my $limit = 1024 * ($self->config ("limit memory") || 32768);
+	my $limit = 1024 * ($self->config ("limit memory") || 65536);
 	$self->_set_rlimit ("RLIMIT_DATA", $limit) if $limit >= 0;
 
 	$limit = $self->config ("limit nr processes") || 10;

--- a/t/240abort.t
+++ b/t/240abort.t
@@ -72,7 +72,7 @@ foreach my $mode ('A', 'I')
        Proto => "tcp")
 	or die "socket: $!";
 
-    for (my $i = 0; $i < 50_000; ++$i)
+    for (my $i = 0; $i < 1_000; ++$i)
       {
 	$sock->printf ("This is line %d. %s\r\n", $i, "a" x 1_000);
       }


### PR DESCRIPTION
With Linux 4.7 the value of RLIMIT_DATA is respected in calls to mmap
- a process wanting to allocate (in sum) more memory than RLIMIT_DATA
specifies will not be able to do so.

In FTPServer.pm the default limit is set to 16384 kilobytes.
This commit doubles the default memory limit so t/170files.t does not
fail anymore.

t/240abort.t originally constructs a huge string to simulate a big
file, also breaking the RLIMIT_DATA set.
This commit cuts down the string to a sane size not breaking the limit.